### PR TITLE
Add 3DS support.

### DIFF
--- a/api.yml
+++ b/api.yml
@@ -749,7 +749,42 @@ paths:
             items:
               title: error
               type: string
+        301:
+          description: 3DS Validation Redirect
+          headers:
+            Location:
+              type: "string"
 
+  /complete_recharge/:id:
+    get:
+      description: |
+        Recharge account completion step after a successful 3DS payment validation.
+
+        The clients MUST never call this endpoint directly, but instead use the 3DS
+        Validation Redirect URL from Mangopay. Once that page returns succesfully it
+        will redirect to this page with the appropriate transaction id.
+      parameters:
+        -
+          name: id
+          in: query
+          description: |
+            Succesfully validated 3DS PayIn transaction id of a Recharge Account.
+          required: true
+          type: string
+      responses:
+        200:
+          description: Successfull transaction
+          schema:
+            title: message
+            type: string
+        400:
+          description: Missing or wrong parameter
+          schema:
+            title: errors
+            type: array
+            items:
+              title: error
+              type: string
 
   /pay_subscription:
     post:
@@ -791,6 +826,42 @@ paths:
               type: string
         401:
           description: Authorization error
+          schema:
+            title: errors
+            type: array
+            items:
+              title: error
+              type: string
+        301:
+          description: 3DS Validation Redirect
+          headers:
+            Location:
+              type: "string"
+
+  /complete_subscription/:id:
+    get:
+      description: |
+        Subscription completion step after a successful 3DS payment validation.
+
+        The clients MUST never call this endpoint directly, but instead use the 3DS
+        Validation Redirect URL from Mangopay. Once that page returns succesfully it
+        will redirect to this endpoint with the appropriate transaction id.
+      parameters:
+        -
+          name: id
+          in: query
+          description: |
+            Succesfully validated 3DS PayIn transaction id of a Subcription.
+          required: true
+          type: string
+      responses:
+        200:
+          description: Successfull transaction
+          schema:
+            title: message
+            type: string
+        400:
+          description: Missing or wrong parameter
           schema:
             title: errors
             type: array


### PR DESCRIPTION
3DS payment validation takes an extra step for validation. The payment
starts in the API and Mangopay, but instead of a success or failure
Mangopay returns a URL to redirect the user to a bank webpage to
validate the user preagreed 3DS password on than bank.

Once the user successfully authenticates via 3DS the page will proceed
to the API endpoints for completing the step.

This affects account recharges and subscription payments, so a redirect is
added, along with a completion step endpoint for each of them.

Remember clients MUST normally not call the completion endpoints,
for they will be auto-redirected to after a successful 3DS validation.